### PR TITLE
Fixed JSON formatting error

### DIFF
--- a/fabric-cli/cmd/fabric-cli/printer/blockprinter.go
+++ b/fabric-cli/cmd/fabric-cli/printer/blockprinter.go
@@ -1388,7 +1388,11 @@ func (p *BlockPrinter) PrintChaincodeSpec(ccSpec *pb.ChaincodeSpec) {
 func (p *BlockPrinter) PrintChaincodeInput(ccInput *pb.ChaincodeInput) {
 	p.Array("Args")
 	for i, value := range ccInput.Args {
-		p.ItemValue("Arg", i, value)
+		if i == len(ccInput.Args)-1 {
+			p.ItemValue("EndArg", i, value)
+		} else {
+			p.ItemValue("Arg", i, value)
+		}
 	}
 	p.ArrayEnd()
 	p.Array("Decorations")

--- a/fabric-cli/cmd/fabric-cli/printer/formatter.go
+++ b/fabric-cli/cmd/fabric-cli/printer/formatter.go
@@ -283,10 +283,10 @@ func (p *jsonFormatter) ItemEnd() {
 }
 
 func (p *jsonFormatter) ItemValue(element string, index interface{}, value interface{}) {
-	if p.commaRequired {
+	p.write("\"%v\"", p.encodeValue(value))
+	if element == "Arg" {
 		p.write(",")
 	}
-	p.write("\"%v\"", p.encodeValue(value))
 }
 
 func (p *jsonFormatter) Value(value interface{}) {


### PR DESCRIPTION
When using the fabric-cli to query for blocks I encountered an error whereby the chaincode arguments for a block were not returned in correct JSON format. This occurred as they were not correctly separated by commas within the JSON block.

The changes add a comma to items within an array unless they are the last or only item in the array.

Previously a JSON block called may have had a field like this:
```
"Input":{"Args":["bW92ZQ""QQ""Qg""MQ"]
```

This is correct to the following:
```
"Input":{"Args":["bW92ZQ","QQ","Qg","MQ"]
```

HTH